### PR TITLE
Added another example to show contributions by user/month

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ ggplot(df, aes(x=month, y=n)) +
 library(dplyr)
 library(RColorBrewer)
 library(scales)
+library(reshape2)
 repo_path <- getwd()
 # Or change this to a more interesting local repo
 


### PR DESCRIPTION
I expanded on the example that allows you to view contributions by user / repo by month.

For `git2r` it currently looks like this:
![image](https://f.cloud.github.com/assets/138494/2442072/160eb50c-ae1d-11e3-807d-6d822e94a1a4.png)
