### PR TITLE
Remove usage of the extra 'username' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ devtools package:
 ```coffee
 # install.packages("devtools")
 library(devtools)
-install_github("git2r", "ropensci")
+install_github("ropensci/git2r")
 ```
 
 Another alternative is to use `git` and `make`


### PR DESCRIPTION
'username' parameter to install_github() has been
deprecated. The new format should be:

	install_github('ropensci/git2r')

Signed-off-by: Felipe Balbi <balbi@ti.com>