### PR TITLE
Update configuration to build on OpenBSD

### DIFF
--- a/configure
+++ b/configure
@@ -3630,7 +3630,61 @@ have_ssl=no
 if test "x${OPENSSL_INCLUDES}" = x; then :; else
         CPPFLAGS="${CPPFLAGS} -I${OPENSSL_INCLUDES}"
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing SSL_library_init" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing EVP_EncryptInit" >&5
+$as_echo_n "checking for library containing EVP_EncryptInit... " >&6; }
+if ${ac_cv_search_EVP_EncryptInit+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char EVP_EncryptInit ();
+int
+main ()
+{
+return EVP_EncryptInit ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' crypto; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_EVP_EncryptInit=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_EVP_EncryptInit+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_EVP_EncryptInit+:} false; then :
+
+else
+  ac_cv_search_EVP_EncryptInit=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_EVP_EncryptInit" >&5
+$as_echo "$ac_cv_search_EVP_EncryptInit" >&6; }
+ac_res=$ac_cv_search_EVP_EncryptInit
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing SSL_library_init" >&5
 $as_echo_n "checking for library containing SSL_library_init... " >&6; }
 if ${ac_cv_search_SSL_library_init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -3687,68 +3741,11 @@ if test "$ac_res" != no; then :
 fi
 
 
-have_crypto=no
-if test "x${have_ssl}" = xyes; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing EVP_EncryptInit" >&5
-$as_echo_n "checking for library containing EVP_EncryptInit... " >&6; }
-if ${ac_cv_search_EVP_EncryptInit+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_func_search_save_LIBS=$LIBS
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char EVP_EncryptInit ();
-int
-main ()
-{
-return EVP_EncryptInit ();
-  ;
-  return 0;
-}
-_ACEOF
-for ac_lib in '' crypto; do
-  if test -z "$ac_lib"; then
-    ac_res="none required"
-  else
-    ac_res=-l$ac_lib
-    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
-  fi
-  if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_search_EVP_EncryptInit=$ac_res
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext
-  if ${ac_cv_search_EVP_EncryptInit+:} false; then :
-  break
-fi
-done
-if ${ac_cv_search_EVP_EncryptInit+:} false; then :
-
-else
-  ac_cv_search_EVP_EncryptInit=no
-fi
-rm conftest.$ac_ext
-LIBS=$ac_func_search_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_EVP_EncryptInit" >&5
-$as_echo "$ac_cv_search_EVP_EncryptInit" >&6; }
-ac_res=$ac_cv_search_EVP_EncryptInit
-if test "$ac_res" != no; then :
-  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
-  have_crypto=yes
 fi
 
-fi
 
 # Specify sha1 implementation
-if test "x${have_crypto}" = xyes; then
+if test "x${have_ssl}" = xyes; then
         CPPFLAGS="${CPPFLAGS} -DGIT_SSL"
 
         case "${host_os}" in

--- a/configure.ac
+++ b/configure.ac
@@ -128,15 +128,13 @@ have_ssl=no
 if test "x${OPENSSL_INCLUDES}" = x; then :; else
         CPPFLAGS="${CPPFLAGS} -I${OPENSSL_INCLUDES}"
 fi
-AC_SEARCH_LIBS([SSL_library_init], [ssl], [have_ssl=yes])
-
-have_crypto=no
-if test "x${have_ssl}" = xyes; then
-        AC_SEARCH_LIBS([EVP_EncryptInit], [crypto], [have_crypto=yes])
-fi
+AC_SEARCH_LIBS([EVP_EncryptInit], [crypto],
+    [
+        AC_SEARCH_LIBS([SSL_library_init], [ssl], [have_ssl=yes])
+    ])
 
 # Specify sha1 implementation
-if test "x${have_crypto}" = xyes; then
+if test "x${have_ssl}" = xyes; then
         CPPFLAGS="${CPPFLAGS} -DGIT_SSL"
 
         case "${host_os}" in


### PR DESCRIPTION
* configure.ac: Change order of test for libssl and libcrypto to first
  check for libcrypto. It then works to check for libssl.

Signed-off-by: Stefan Widgren <stefan.widgren@gmail.com>