### PR TITLE
config() fails when user.name or user.email are passed as variables

### DIFF
--- a/tests/config.R
+++ b/tests/config.R
@@ -51,6 +51,17 @@ cfg <- config(repo, user.name=NULL, user.email=NULL)
 stopifnot(is.null(cfg$local$user.name))
 stopifnot(is.null(cfg$local$user.email))
 
+## Supply values as objects
+user.name <- "Alice"
+user.email <- "alice@example.org"
+cfg <- config(repo, user.name=user.name, user.email="alice@example.org")
+stopifnot(identical(cfg$local$user.name, user.name))
+stopifnot(identical(cfg$local$user.email, "alice@example.org"))
+cfg <- config(repo, user.name="Alice", user.email=user.email)
+stopifnot(identical(cfg$local$user.name, "Alice"))
+stopifnot(identical(cfg$local$user.email, user.email))
+
+
 ##
 ## Cleanup
 ##


### PR DESCRIPTION
The code below fails in the current version. This makes it impossible the set the user.name and user.email dynamically through code

    user.name <- "Alice"
    user.email <- "alice@example.org"
    cfg <- config(repo, user.name=user.name, user.email=user.email)

This pull request doesn't solve the problem. It just adds some reproducible tests for the bug.