### PR TITLE
status prints something even when working directory is clean

### DIFF
--- a/R/status.r
+++ b/R/status.r
@@ -128,6 +128,9 @@ print.git_status <- function(x, ...)
         invisible(NULL)
     }
 
+    if (max(vapply(x, length, integer(1))) == 0L)
+      cat("working directory clean\n")
+
     if (length(x$ignored)) {
         display_status("Ignored files", x$ignored)
         cat("\n")


### PR DESCRIPTION
When working directory is clean `git status` still prints something, e.g.:

```
jenny@2015-mbp git2r $ git status
On branch master
Your branch is up-to-date with 'origin/master'.
nothing to commit, working directory clean
```

I think it would be nice if the print method for the `git_status` object did similar, so you know it's still working.

