### PR TITLE
Fix installation with parallel make

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -57,7 +57,7 @@ OBJECTS.http_parser = libgit2/deps/http-parser/http_parser.o
 LIBGIT = $(OBJECTS.libgit2) $(OBJECTS.libgit2.transports) $(OBJECTS.libgit2.unix) \
     $(OBJECTS.libgit2.xdiff) $(OBJECTS.http_parser) @GIT2R_SRC_REGEX@
 
-all: libmygit.a
+$(SHLIB): libmygit.a
 
 libmygit.a: $(LIBGIT)
 	$(AR) rcs libmygit.a $(LIBGIT)


### PR DESCRIPTION
I have had problems installing this package on a server that has `Sys.setenv(MAKE = "make -j 16")` in its `.Rprofile`. Editing dependencies has resolved the issue, this is also recommended in R-exts.