### PR TITLE
Use portable string equality comparison operator

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -289,9 +289,9 @@ esac
 
 # Determine architecture of the machine
 AC_CHECK_SIZEOF([void*])
-if test "x$ac_cv_sizeof_voidp" == "x8"; then
+if test "x$ac_cv_sizeof_voidp" = "x8"; then
     CPPFLAGS="${CPPFLAGS} -DGIT_ARCH_64"
-elif test "x$ac_cv_sizeof_voidp" == "x4"; then
+elif test "x$ac_cv_sizeof_voidp" = "x4"; then
     CPPFLAGS="${CPPFLAGS} -DGIT_ARCH_32"
 else
     AC_MSG_FAILURE([Unsupported architecture])


### PR DESCRIPTION
This fixes the build e.g. for those without Bash as `/bin/sh`. See also: https://github.com/koalaman/shellcheck/issues/686 .