### PR TITLE
Add 'checkout' argument to 'clone()'

### DIFF
--- a/R/repository.r
+++ b/R/repository.r
@@ -258,6 +258,7 @@ setMethod("init",
 ##' @param bare Create a bare repository. Default is FALSE.
 ##' @param branch The name of the branch to checkout. Default is NULL
 ##' which means to use the remote's default branch.
+##' @param checkout Checkout HEAD after the clone is complete. Default is TRUE.
 ##' @param credentials The credentials for remote repository
 ##' access. Default is NULL. To use and query an ssh-agent for the ssh
 ##' key credentials, let this parameter be NULL (the default).
@@ -312,6 +313,7 @@ setGeneric("clone",
                     local_path,
                     bare        = FALSE,
                     branch      = NULL,
+                    checkout    = TRUE,
                     credentials = NULL,
                     progress    = TRUE)
            standardGeneric("clone"))
@@ -325,11 +327,12 @@ setMethod("clone",
                    local_path,
                    bare,
                    branch,
+                   checkout,
                    credentials,
                    progress)
           {
               .Call(git2r_clone, url, local_path, bare,
-                    branch, credentials, progress)
+                    branch, checkout, credentials, progress)
 
               repository(local_path)
           }

--- a/man/clone-methods.Rd
+++ b/man/clone-methods.Rd
@@ -6,11 +6,11 @@
 \alias{clone,character,character-method}
 \title{Clone a remote repository}
 \usage{
-clone(url, local_path, bare = FALSE, branch = NULL, credentials = NULL,
-  progress = TRUE)
+clone(url, local_path, bare = FALSE, branch = NULL, checkout = TRUE,
+  credentials = NULL, progress = TRUE)
 
 \S4method{clone}{character,character}(url, local_path, bare = FALSE,
-  branch = NULL, credentials = NULL, progress = TRUE)
+  branch = NULL, checkout = TRUE, credentials = NULL, progress = TRUE)
 }
 \arguments{
 \item{url}{The remote repository to clone}
@@ -21,6 +21,8 @@ clone(url, local_path, bare = FALSE, branch = NULL, credentials = NULL,
 
 \item{branch}{The name of the branch to checkout. Default is NULL
 which means to use the remote's default branch.}
+
+\item{checkout}{Checkout HEAD after the clone is complete. Default is TRUE.}
 
 \item{credentials}{The credentials for remote repository
 access. Default is NULL. To use and query an ssh-agent for the ssh

--- a/src/git2r.c
+++ b/src/git2r.c
@@ -84,7 +84,7 @@ static const R_CallMethodDef callMethods[] =
     CALLDEF(git2r_branch_upstream_canonical_name, 1),
     CALLDEF(git2r_checkout_path, 2),
     CALLDEF(git2r_checkout_tree, 3),
-    CALLDEF(git2r_clone, 6),
+    CALLDEF(git2r_clone, 7),
     CALLDEF(git2r_commit, 4),
     CALLDEF(git2r_commit_parent_list, 1),
     CALLDEF(git2r_commit_tree, 1),

--- a/src/git2r_clone.c
+++ b/src/git2r_clone.c
@@ -71,6 +71,7 @@ static int git2r_clone_progress(
  * @param bare Create a bare repository.
  * @param branch The name of the branch to checkout. Default is NULL
  *        which means to use the remote's default branch.
+ * @param checkout Checkout HEAD after the clone is complete.
  * @param credentials The credentials for remote repository access.
  * @param progress show progress
  * @return R_NilValue
@@ -80,6 +81,7 @@ SEXP git2r_clone(
     SEXP local_path,
     SEXP bare,
     SEXP branch,
+    SEXP checkout,
     SEXP credentials,
     SEXP progress)
 {
@@ -97,12 +99,18 @@ SEXP git2r_clone(
         git2r_error(__func__, NULL, "'bare'", git2r_err_logical_arg);
     if (branch != R_NilValue && git2r_arg_check_string(branch))
         git2r_error(__func__, NULL, "'branch'", git2r_err_string_arg);
+    if (git2r_arg_check_logical(checkout))
+        git2r_error(__func__, NULL, "'checkout'", git2r_err_logical_arg);
     if (git2r_arg_check_credentials(credentials))
         git2r_error(__func__, NULL, "'credentials'", git2r_err_credentials_arg);
     if (git2r_arg_check_logical(progress))
         git2r_error(__func__, NULL, "'progress'", git2r_err_logical_arg);
 
-    checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
+    if (LOGICAL(checkout)[0])
+      checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
+    else
+      checkout_opts.checkout_strategy = GIT_CHECKOUT_NONE;
+    
     clone_opts.checkout_opts = checkout_opts;
     payload.credentials = credentials;
     clone_opts.fetch_opts.callbacks.payload = &payload;

--- a/src/git2r_clone.h
+++ b/src/git2r_clone.h
@@ -27,6 +27,7 @@ SEXP git2r_clone(
     SEXP local_path,
     SEXP bare,
     SEXP branch,
+    SEXP checkout,
     SEXP credentials,
     SEXP progress);
 

--- a/tests/clone_checkout.R
+++ b/tests/clone_checkout.R
@@ -1,0 +1,63 @@
+## git2r, R bindings to the libgit2 library.
+## Copyright (C) 2013-2015 The git2r contributors
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License, version 2,
+## as published by the Free Software Foundation.
+##
+## git2r is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+library(git2r)
+
+## For debugging
+sessionInfo()
+
+## Create 2 directories in tempdir
+path_src <- tempfile(pattern="git2r-")
+path_tgt <- tempfile(pattern="git2r-")
+dir.create(path_tgt)
+dir.create(path_src)
+
+## Initialize a repository
+repo_src <- init(path_src)
+config(repo_src, user.name="Alice", user.email="alice@example.org")
+
+## Add commit to repo
+filename <- "test.txt"
+writeLines("Hello world", con = file.path(path_src, filename))
+add(repo_src, "test.txt")
+commit_src <- commit(repo_src, "Commit message")
+
+## Check checkout argument
+tools::assertError(clone(path_src, path_tgt, checkout = c(FALSE, TRUE)))
+tools::assertError(clone(path_src, path_tgt, checkout = 1))
+tools::assertError(clone(path_src, path_tgt, checkout = 1L))
+tools::assertError(clone(path_src, path_tgt, checkout = "test"))
+
+## Clone source to target repository without checking out any files
+repo_tgt <- clone(path_src, path_tgt, checkout = FALSE)
+
+## List files in the repositores
+stopifnot(identical(list.files(path_src), filename))
+stopifnot(identical(list.files(path_tgt), character(0)))
+
+## Compare commits
+stopifnot(identical(length(commits(repo_tgt)), 1L))
+commit_tgt <- commits(repo_tgt)[[1]]
+stopifnot(identical(commit_src@sha, commit_tgt@sha))
+stopifnot(identical(commit_src@author, commit_tgt@author))
+stopifnot(identical(commit_src@committer, commit_tgt@committer))
+stopifnot(identical(commit_src@summary, commit_tgt@summary))
+stopifnot(identical(commit_src@message, commit_tgt@message))
+stopifnot(!identical(commit_src@repo, commit_tgt@repo))
+
+## Cleanup
+unlink(path_tgt, recursive=TRUE)
+unlink(path_src, recursive=TRUE)


### PR DESCRIPTION
Allows to control whether checkout of HEAD is performed after the clone is complete. Setting `checkout=FALSE` has similar effect as the git command line option `--no-checkout`.