### PR TITLE
Enable argument 'all' to commit multiple modified (or deleted) files.

### DIFF
--- a/R/commit.r
+++ b/R/commit.r
@@ -151,15 +151,18 @@ setMethod("commit",
                               untracked = FALSE,
                               ignored   = FALSE)
 
-                  ## Stage modified files
-                  lapply(s$unstaged$modified, function(x) {
-                      add(repo, x)
-                  })
+                  # Convert list of lists to character vector
+                  unstaged <- unlist(s$unstaged)
+                  for (i in seq_along(unstaged)) {
+                    if (names(unstaged)[i] == "modified") {
+                      ## Stage modified files
+                      add(repo, unstaged[i])
+                    } else if (names(unstaged)[i] == "deleted") {
+                      ## Stage deleted files
+                      .Call(git2r_index_remove_bypath, repo, unstaged[i])
+                    }
+                  }
 
-                  ## Stage deleted files
-                  lapply(s$unstaged$deleted, function(x) {
-                      .Call(git2r_index_remove_bypath, repo, x)
-                  })
               }
 
               if (session)

--- a/tests/commit.R
+++ b/tests/commit.R
@@ -81,43 +81,69 @@ writeLines(c("Hello world!", "HELLO WORLD!", "HeLlO wOrLd!"),
            file.path(path, "test.txt"))
 commit(repo, "Commit message 3", all = TRUE)
 
-stopifnot(identical(status(repo),
-                    structure(list(
-                        staged = structure(list(), .Names = character(0)),
-                        unstaged = structure(list(), .Names = character(0)),
-                        untracked = structure(list(), .Names = character(0))),
-                              .Names = c("staged", "unstaged", "untracked"),
-                              class = "git_status")))
+status_clean <- structure(list(
+  staged = structure(list(), .Names = character(0)),
+  unstaged = structure(list(), .Names = character(0)),
+  untracked = structure(list(), .Names = character(0))),
+  .Names = c("staged", "unstaged", "untracked"),
+  class = "git_status")
+stopifnot(identical(status(repo), status_clean))
 
 ## Delete file and commit with 'all' argument
 file.remove(file.path(path, "test.txt"))
 commit(repo, "Commit message 4", all = TRUE)
 
-stopifnot(identical(status(repo),
-                    structure(list(
-                        staged = structure(list(), .Names = character(0)),
-                        unstaged = structure(list(), .Names = character(0)),
-                        untracked = structure(list(), .Names = character(0))),
-                              .Names = c("staged", "unstaged", "untracked"),
-                              class = "git_status")))
+stopifnot(identical(status(repo), status_clean))
+
+## Add and commit multiple tracked files with 'all' argument
+writeLines(sample(letters, 3), file.path(path, "test2.txt"))
+add(repo, "test2.txt")
+writeLines(sample(letters, 3), file.path(path, "test3.txt"))
+add(repo, "test3.txt")
+writeLines(sample(letters, 3), file.path(path, "test4.txt"))
+add(repo, "test4.txt")
+commit(repo, "Commit message 5")
+
+stopifnot(identical(status(repo), status_clean))
+
+writeLines(sample(letters, 3), file.path(path, "test2.txt"))
+writeLines(sample(letters, 3), file.path(path, "test3.txt"))
+writeLines(sample(letters, 3), file.path(path, "test4.txt"))
+commit(repo, "Commit message 6", all = TRUE)
+
+stopifnot(identical(status(repo), status_clean))
+
+## Add one tracked file and delete another with 'all' argument
+writeLines(sample(letters, 3), file.path(path, "test2.txt"))
+file.remove(file.path(path, "test4.txt"))
+commit(repo, "Commit message 7", all = TRUE)
+
+stopifnot(identical(status(repo), status_clean))
+
+## Delete multiple tracked files with 'all' argument
+file.remove(file.path(path, "test2.txt"))
+file.remove(file.path(path, "test3.txt"))
+commit(repo, "Commit message 8", all = TRUE)
+
+stopifnot(identical(status(repo), status_clean))
 
 ## Check max number of commits in output
-stopifnot(identical(length(commits(repo)), 4L))
-stopifnot(identical(length(commits(repo, n = -1)), 4L))
+stopifnot(identical(length(commits(repo)), 8L))
+stopifnot(identical(length(commits(repo, n = -1)), 8L))
 stopifnot(identical(length(commits(repo, n = 2)), 2L))
 tools::assertError(commits(repo, n = 2.2))
 tools::assertError(commits(repo, n = "2"))
 
 ## Check to coerce repository to data.frame
 df <- as(repo, "data.frame")
-stopifnot(identical(dim(df), c(4L, 6L)))
+stopifnot(identical(dim(df), c(8L, 6L)))
 stopifnot(identical(names(df), c("sha", "summary", "message",
                                  "author", "email", "when")))
 
 ## Set working directory to path and check commits
 setwd(path)
-stopifnot(identical(length(commits()), 4L))
-stopifnot(identical(length(commits(n = -1)), 4L))
+stopifnot(identical(length(commits()), 8L))
+stopifnot(identical(length(commits(n = -1)), 8L))
 stopifnot(identical(length(commits(n = 2)), 2L))
 tools::assertError(commits(n = 2.2))
 tools::assertError(commits(n = "2"))


### PR DESCRIPTION
I observed the behavior that setting the argument `all = TRUE` for `commit` only commits one tracked file instead of all tracked files. The unit tests only test for [one modified file](https://github.com/ropensci/git2r/blob/1a1c3921095223034e20fd0abf39dcd36df5ac06/tests/commit.R#L79) or [one deleted file](https://github.com/ropensci/git2r/blob/1a1c3921095223034e20fd0abf39dcd36df5ac06/tests/commit.R#L92). I think the issue is from [line #155 in commit.r](https://github.com/ropensci/git2r/blob/1a1c3921095223034e20fd0abf39dcd36df5ac06/R/commit.r#L155). `s$unstaged` is a named list, thus passing `s$unstaged$modified` to `lapply` is only passing one element of the list. Here's a small example to illustrate:

```
s <- list(unstaged = list(modified = "file1.txt", modified = "file2.txt"))
lapply(s$unstaged$modified, function(x) x)
## [[1]]
## [1] "file1.txt"
```

I updated `commit` so that it will iterate over all tracked files and also added some unit tests. I was able to run `make check` successfully with R 3.4.0 on Ubuntu 16.10. Please let me know if you would like me to make any modifications.