### PR TITLE
add repo <- repository() example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ The central object in the `git2r` package is the S4 class
 `git_repository`. The following three methods can instantiate a
 repository; `init`, `repository` and `clone`.
 
+#### Open an existing repository
+
+Use `repository` if you are already working in a git repository.
+
+```
+repo <- repository()
+```
+
 #### Create a new repository
 
 Create a new repository in a temporary directory using `init`


### PR DESCRIPTION
I assume mine is a very frequent (perhaps most common?) use case: I have a repository and would like to use git in Rstudio w/o using the Rstudio shell, so I remember / find this package and want to get started.

It took me more than _n_ seconds after installation + _m_ seconds after finding the readme to figure out that I could do:

```
repo <- repository()
```

so hopefully this will make it easier for the next person with my use case