### PR TITLE
[WIP] Force add a file that is in an ignored subdirectory

### DIFF
--- a/tests/add-force.R
+++ b/tests/add-force.R
@@ -71,5 +71,44 @@ s_3 <- structure(list(staged = structure(list(), .Names = character(0)),
 commit(repo, "Second commit message")
 stopifnot(identical(status(repo, ignored = TRUE), s_3))
 
+## Ignore a subdirectory
+writeLines("subdir", file.path(path, ".gitignore"))
+
+add(repo, ".gitignore")
+commit(repo, "Ignore subdir")
+
+## Create subdirectory and a file inside
+d_ignore <- file.path(path, "subdir")
+dir.create(d_ignore)
+
+writeLines("An exception", file.path(d_ignore, "force.txt"))
+
+s_4 <- structure(list(staged = structure(list(), .Names = character(0)),
+                      unstaged = structure(list(), .Names = character(0)),
+                      untracked = structure(list(), .Names = character(0)),
+                      ignored = structure(list(ignored = "subdir/"), .Names = "ignored")),
+                 .Names = c("staged", "unstaged", "untracked", "ignored"),
+                 class = "git_status")
+stopifnot(identical(status(repo, ignored = TRUE), s_4))
+
+## The file is ignored and should not be added
+add(repo, "subdir/force.txt")
+stopifnot(identical(status(repo, ignored = TRUE), s_4))
+
+## The file is ignored but should be added with force
+add(repo, "subdir/force.txt", force = TRUE)
+
+s_5 <- structure(list(staged = structure(list(new = "subdir/test.txt"), .Names = "new"),
+                      unstaged = structure(list(), .Names = character(0)),
+                      untracked = structure(list(), .Names = character(0)),
+                      ignored = structure(list(ignored = "subdir/"), .Names = "ignored")),
+                 .Names = c("staged", "unstaged", "untracked", "ignored"),
+                 class = "git_status")
+stopifnot(identical(status(repo, ignored = TRUE), s_5))
+
+## Commit and check status
+commit(repo, "Commit file in ignored subdirectory")
+stopifnot(identical(status(repo, ignored = TRUE), s_4))
+
 ## Cleanup
 unlink(path, recursive=TRUE)


### PR DESCRIPTION
## Motivation

A common setup I use for my Git repositories is to ignore entire directories which contain many files that I do not want to commit, e.g. subdirectories with data or figure files. Ignoring these directories prevents me from accidentally committing them and makes the output of `git status` less cluttered. However, I often want to commit a few files from these ignored subdirectories, e.g. a small data file with summary statistics or the final version of a figure I want to share. This is possible with Git, e.g.

```
$ cat .gitignore
data/
$ git add -f data/summary.txt
```

## Problem

I am unable to force add a file in an ignored subdirectory with `git2r::add()`. Using the example above, `git2r::add("data/summary.txt", force = TRUE)` does not force add the file, nor does it throw a warning or error. It behaves the same as if `force = FALSE`.

## What's currently in this PR

I haven't been able to figure out how to implement this myself, but to assist in developing a solution, I've added unit tests that currently fail but should pass if the behavior is implemented.

## Researching potential solutions

PR https://github.com/ropensci/git2r/issues/148 was the original request for force adding files, and commit https://github.com/ropensci/git2r/commit/7ccb20279974f2fb7a567f6aa98ca2f2ee07f544 implemented the functionality. However, the focus was on ignored files, and not ignored subdirectories.

I have been trying to determine if this is a fundamental limitation of libgit2. The libgit2 docs for [git_index_add_all](https://libgit2.github.com/libgit2/#HEAD/group/index/git_index_add_all) discuss force adding specific files with the `GIT_INDEX_ADD_FORCE` flag, but do not discuss this specific use case. Looking at the Python API for libgit2, [pygit2](https://github.com/libgit2/pygit2), it appears that they do not support force adding at all ([source code](https://github.com/libgit2/pygit2/blob/24d385a88f9a4e2540ea2c04fa86d76e7c4e17ee/pygit2/index.py#L187), [search results of online documentation](http://www.pygit2.org/search.html?q=force&check_keywords=yes&area=default#)), so that's not informative. The Lua API, [luagit2](https://github.com/libgit2/luagit2), also appears to not handle ignored files, instead [recommending](https://libgit2.github.com/luagit2/modules/Index.html#Index:add) that this be implemented manually: "This forces the file to be added to the index, not looking at gitignore rules. Those rules can be evaluated through the git_status APIs (in status.h) before calling this."

This issue is potentially related: https://github.com/libgit2/libgit2/issues/3535#issuecomment-162328564 At the very least it demonstrates an example where Git and libgit2 differ in their interpretation of the `.gitingore` file.

Would it be possible to implement this functionality in git2r either by modifying the call to libgit2 or instead adding a custom check via a call to `git2r::status()`?