### PR TITLE
Ensure that git2r writes the config file to the correct location on Windows

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -82,6 +82,18 @@ config <- function(repo = NULL, global = FALSE, user.name, user.email, ...)
 
         if (isTRUE(global)) {
             repo <- NULL
+            if (.Platform$OS.type == "windows") {
+              # Ensure that git2r writes the config file to the root of the
+              # user's home directory by first creating an empty file. Otherwise
+              # it may be written to the user's Documents/ directory.
+              drive <- Sys.getenv("HOMEDRIVE")
+              login <- Sys.info()["login"]
+              home <- file.path(drive, "Users", login)
+              config_global <- file.path(home, ".gitconfig")
+              if (!file.exists(config_global)) {
+                file.create(config_global)
+              }
+            }
         } else if (is.null(repo)) {
             stop("Unable to locate local repository")
         }

--- a/tests/config.R
+++ b/tests/config.R
@@ -58,5 +58,14 @@ stopifnot(identical(dim(cfg), c(4L, 2L)))
 stopifnot(identical(cfg$file, c("system", "xdg", "global", "local")))
 stopifnot(!is.na(cfg$path[4]))
 
+## Check location of .gitconfig on Windows
+if (identical(Sys.getenv("APPVEYOR"), "True")) {
+  config(global = TRUE, user.name = "name", email = "email")
+  gitconfig_expected <- file.path(Sys.getenv("HOMEDRIVE"), "Users",
+                                  Sys.info()["login"])
+  stopifnot(file.exists(gitconfig_expected))
+  unlink(gitconfig_expected)
+}
+
 ## Cleanup
 unlink(path, recursive=TRUE)


### PR DESCRIPTION
## Summary

On Windows, the default location for writing and reading `.gitconfig` differs between `git2r::config` and Git run via PowerShell or Git Bash. This PR implements a fix so that the config file is always written to the same location in the root of the user directory.

## Explanation

On Windows, `git2r::config` with `global = TRUE` saves `.gitconfig` to the user's Documents directory. This is presumably due to the fact `~` maps to `Documents/` on Windows ([source](https://cran.r-project.org/bin/windows/base/rw-FAQ.html#What-are-HOME-and-working-directories_003f)).

```
setwd("C:/Users/john/")
# Using the development version of git2r
packageVersion("git2r")
## [1] '0.21.0.9000'
library("git2r")

normalizePath("~")
## [1] "C:\\Users\\john\\Documents"

# When no Git config files exist
file.exists("C:/Users/john/.gitconfig")
## [1] FALSE
file.exists("C:/Users/john/Documents/.gitconfig")
## [1] FALSE
git_config_files()
##     file path
## 1 system <NA>
## 2    xdg <NA>
## 3 global <NA>
## 4  local <NA>

# git2r::config creates the global config file in Documents/
config(global = TRUE, user.name = "name", user.email = "email")

file.exists("C:/Users/john/.gitconfig")
## [1] FALSE
file.exists("C:/Users/john/Documents/.gitconfig")
## [1] TRUE
git_config_files()
##     file                               path
## 1 system                               <NA>
## 2    xdg                               <NA>
## 3 global C:/Users/john/Documents/.gitconfig
## 4  local                               <NA>
```

Then Git can't find the configuration when run from PowerShell or Git Bash:

```
# PowerShell
PS C:\Users\john> git config --get user.name
PS C:\Users\john> git config --get user.email
```


```
# Git Bash
john@LAPTOP-IRFAT6LT MINGW64 ~
$ git config --get user.name

john@LAPTOP-IRFAT6LT MINGW64 ~
$ git config --get user.email

```

However, if an empty `.gitconfig` exists in the user's root directory, then `git2r::config` writes to this file.

```
setwd("C:/Users/john/")
library("git2r")

# git2r::config writes to the user's root directory if the file already exists
unlink("C:/Users/john/Documents/.gitconfig")
file.create("C:/Users/john/.gitconfig")
## [1] TRUE

config(global = TRUE, user.name = "name", user.email = "email")

file.exists("C:/Users/john/.gitconfig")
## [1] TRUE
file.exists("C:/Users/john/Documents/.gitconfig")
## [1] FALSE
git_config_files()
##     file                     path
## 1 system                     <NA>
## 2    xdg                     <NA>
## 3 global C:/Users/john/.gitconfig
## 4  local                     <NA>
```

And then the config settings are recognized from Git at the command-line:

```
# PowerShell
PS C:\Users\john> git config --get user.name
name
PS C:\Users\john> git config --get user.email
email
```


```
john@LAPTOP-IRFAT6LT MINGW64 ~
$ git config --get user.name
name

john@LAPTOP-IRFAT6LT MINGW64 ~
$ git config --get user.email
email

```

To find the user's actual home directory from R, I used this [suggestion from the R help mailing list](https://stat.ethz.ch/pipermail/r-help/2007-March/128221.html) to use the environment variable `"HOMEDRIVE"`. I didn't also use the environment variable `"HOMEPATH"` because for my own project this failed on AppVeyor (and thus may fail on other Windows machines).