### PR TITLE
Refactor code for finding home directory on Windows

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -90,7 +90,7 @@ config <- function(repo = NULL, global = FALSE, user.name, user.email, ...)
               # options to set and no global config file exists.
               config_files <- git_config_files()
               config_global <- config_files$path[config_files$file == "global"]
-              if (!is.na(config_global) && length(variables) > 0) {
+              if (is.na(config_global) && length(variables) > 0) {
                 file.create(file.path(home(), ".gitconfig"))
               }
             }

--- a/R/config.R
+++ b/R/config.R
@@ -87,10 +87,11 @@ config <- function(repo = NULL, global = FALSE, user.name, user.email, ...)
               # user's home directory by first creating an empty file. Otherwise
               # it may be written to the user's Documents/ directory. Only
               # create the empty file if the user has specified configuration
-              # options to set.
-              config_global <- file.path(home(), ".gitconfig")
-              if (!file.exists(config_global) && length(variables) > 0) {
-                file.create(config_global)
+              # options to set and no global config file exists.
+              config_files <- git_config_files()
+              config_global <- config_files$path[config_files$file == "global"]
+              if (!is.na(config_global) && length(variables) > 0) {
+                file.create(file.path(home(), ".gitconfig"))
               }
             }
         } else if (is.null(repo)) {

--- a/R/config.R
+++ b/R/config.R
@@ -86,10 +86,7 @@ config <- function(repo = NULL, global = FALSE, user.name, user.email, ...)
               # Ensure that git2r writes the config file to the root of the
               # user's home directory by first creating an empty file. Otherwise
               # it may be written to the user's Documents/ directory.
-              drive <- Sys.getenv("HOMEDRIVE")
-              login <- Sys.info()["login"]
-              home <- file.path(drive, "Users", login)
-              config_global <- file.path(home, ".gitconfig")
+              config_global <- file.path(home(), ".gitconfig")
               if (!file.exists(config_global)) {
                 file.create(config_global)
               }

--- a/R/config.R
+++ b/R/config.R
@@ -91,7 +91,7 @@ config <- function(repo = NULL, global = FALSE, user.name, user.email, ...)
               config_files <- git_config_files()
               config_global <- config_files$path[config_files$file == "global"]
               if (is.na(config_global) && length(variables) > 0) {
-                file.create(file.path(home(), ".gitconfig"))
+                file.create(file.path(home_dir(), ".gitconfig"))
               }
             }
         } else if (is.null(repo)) {

--- a/R/config.R
+++ b/R/config.R
@@ -85,9 +85,11 @@ config <- function(repo = NULL, global = FALSE, user.name, user.email, ...)
             if (.Platform$OS.type == "windows") {
               # Ensure that git2r writes the config file to the root of the
               # user's home directory by first creating an empty file. Otherwise
-              # it may be written to the user's Documents/ directory.
+              # it may be written to the user's Documents/ directory. Only
+              # create the empty file if the user has specified configuration
+              # options to set.
               config_global <- file.path(home(), ".gitconfig")
-              if (!file.exists(config_global)) {
+              if (!file.exists(config_global) && length(variables) > 0) {
                 file.create(config_global)
               }
             }

--- a/R/credential.R
+++ b/R/credential.R
@@ -196,11 +196,11 @@ ssh_key_needs_passphrase <- function(privatekey = ssh_path("id_rsa")) {
 ##' ssh_path()
 ##' ssh_path("is_rsa.pub")
 ssh_path <- function(file = "") {
-  file.path(home(), ".ssh", file)
+  file.path(home_dir(), ".ssh", file)
 }
 
 # Return the user's home directory regardless of operating system
-home <- function() {
+home_dir <- function() {
   if (.Platform$OS.type == "windows") {
     home <- Sys.getenv("USERPROFILE")
   } else {

--- a/R/credential.R
+++ b/R/credential.R
@@ -196,12 +196,15 @@ ssh_key_needs_passphrase <- function(privatekey = ssh_path("id_rsa")) {
 ##' ssh_path()
 ##' ssh_path("is_rsa.pub")
 ssh_path <- function(file = "") {
-  
+  file.path(home(), ".ssh", file)
+}
+
+# Return the user's home directory regardless of operating system
+home <- function() {
   if (.Platform$OS.type == "windows") {
     home <- Sys.getenv("USERPROFILE")
   } else {
     home <- path.expand("~")
   }
-  
-  file.path(home, ".ssh", file)
+  return(home)
 }

--- a/tests/config.R
+++ b/tests/config.R
@@ -61,8 +61,7 @@ stopifnot(!is.na(cfg$path[4]))
 ## Check location of .gitconfig on Windows
 if (identical(Sys.getenv("APPVEYOR"), "True")) {
   config(global = TRUE, user.name = "name", email = "email")
-  gitconfig_expected <- file.path(Sys.getenv("HOMEDRIVE"), "Users",
-                                  Sys.info()["login"])
+  gitconfig_expected <- Sys.getenv("USERPROFILE")
   stopifnot(file.exists(gitconfig_expected))
   unlink(gitconfig_expected)
 }

--- a/tests/config.R
+++ b/tests/config.R
@@ -60,8 +60,17 @@ stopifnot(!is.na(cfg$path[4]))
 
 ## Check location of .gitconfig on Windows
 if (identical(Sys.getenv("APPVEYOR"), "True")) {
-  config(global = TRUE, user.name = "name", email = "email")
-  gitconfig_expected <- Sys.getenv("USERPROFILE")
+  gitconfig_expected <- file.path(Sys.getenv("USERPROFILE"), ".gitconfig")
+  ## .gitconfig should not be created if no configuration options specified
+  config(global = TRUE)
+  stopifnot(!file.exists(gitconfig_expected))
+  ## .gitconfig should be created in the user's home directory
+  config(global = TRUE, user.name = "name", user.email = "email")
+  stopifnot(file.exists(gitconfig_expected))
+  unlink(gitconfig_expected)
+  ## .gitconfig should be created if user specifies option other than user.name
+  ## and user.email
+  config(global = TRUE, core.editor = "nano")
   stopifnot(file.exists(gitconfig_expected))
   unlink(gitconfig_expected)
 }

--- a/tests/config.R
+++ b/tests/config.R
@@ -69,7 +69,7 @@ if (identical(Sys.getenv("APPVEYOR"), "True")) {
 
   ## Temporarily move AppVeyor .gitconfig
   gitconfig_appveyor <- "C:/Users/appveyor/.gitconfig"
-  gitconfig_tmp <- "/tmp/.gitconfig"
+  gitconfig_tmp <- file.path(tempdir(), ".gitconfig")
   file.rename(gitconfig_appveyor, gitconfig_tmp)
 
   ## Test config() on Windows

--- a/tests/config.R
+++ b/tests/config.R
@@ -86,6 +86,13 @@ if (identical(Sys.getenv("APPVEYOR"), "True")) {
   config(global = TRUE, core.editor = "nano")
   stopifnot(file.exists(gitconfig_expected))
   unlink(gitconfig_expected)
+  ## .gitconfig should not create a new .gitconfig if the user already has one
+  ## in Documents/
+  gitconfig_documents <- "~/.gitconfig"
+  file.create(gitconfig_documents)
+  config(global = TRUE, core.editor = "nano")
+  stopifnot(!file.exists(gitconfig_expected))
+  unlink(gitconfig_documents)
 
   ## Return AppVeyor .gitconfig
   file.rename(gitconfig_tmp, gitconfig_appveyor)


### PR DESCRIPTION
The main change in this PR is refactoring `ssh_path` to create a new function `home` that returns the user's home directory regardless of operating system. It is currently used by `ssh_path` and `config`.

xref: #317 #320

It also has two other minor changes:

1. The empty .gitconfig is only created if the user has specified configuration options
1. I fixed a [typo](https://github.com/ropensci/git2r/blob/94fc3f5a53c3c0444c3a175ca8370448a67d1b52/tests/config.R#L63) in my previous unit test. I passed `email` to `config` instead of `user.email`. This generated a warning message on my local Windows machine. Should that have been detected on AppVeyor? I used the [conditional statement](https://github.com/r-lib/testthat/blob/1faa32fc1afa769ac16bdb5792fd597324143c57/R/skip.R#L145) used by `testthat::skip_on_appveyor`, but I don't know if that works outside of testthat (in other words, is the environment variable `"APPVEYOR"` created by AppVeyor or testthat?).