### PR TITLE
Avoid internal git-buf API where possible

### DIFF
--- a/src/git2r.c
+++ b/src/git2r.c
@@ -28,7 +28,7 @@
 #include <Rinternals.h>
 #include <R_ext/Rdynload.h>
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_blame.h"
 #include "git2r_blob.h"

--- a/src/git2r_arg.c
+++ b/src/git2r_arg.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_error.h"

--- a/src/git2r_arg.h
+++ b/src/git2r_arg.h
@@ -21,7 +21,7 @@
 
 #include <R.h>
 #include <Rinternals.h>
-#include "git2.h"
+#include <git2.h>
 
 int git2r_arg_check_blob(SEXP arg);
 int git2r_arg_check_branch(SEXP arg);

--- a/src/git2r_blame.c
+++ b/src/git2r_blame.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_blame.h"

--- a/src/git2r_blob.h
+++ b/src/git2r_blob.h
@@ -21,7 +21,7 @@
 
 #include <R.h>
 #include <Rinternals.h>
-#include "git2.h"
+#include <git2.h>
 
 SEXP git2r_blob_content(SEXP blob);
 SEXP git2r_blob_create_fromdisk(SEXP repo, SEXP path);

--- a/src/git2r_branch.h
+++ b/src/git2r_branch.h
@@ -21,7 +21,7 @@
 
 #include <R.h>
 #include <Rinternals.h>
-#include "git2.h"
+#include <git2.h>
 
 SEXP git2r_branch_canonical_name(SEXP branch);
 SEXP git2r_branch_create(SEXP branch_name, SEXP commit, SEXP force);

--- a/src/git2r_checkout.c
+++ b/src/git2r_checkout.c
@@ -16,8 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
-#include "refs.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_checkout.h"

--- a/src/git2r_clone.c
+++ b/src/git2r_clone.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_clone.h"

--- a/src/git2r_commit.c
+++ b/src/git2r_commit.c
@@ -16,9 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
-#include "buffer.h"
-#include "commit.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_commit.h"

--- a/src/git2r_commit.h
+++ b/src/git2r_commit.h
@@ -22,7 +22,7 @@
 #include <R.h>
 #include <Rinternals.h>
 
-#include "git2.h"
+#include <git2.h>
 
 SEXP git2r_commit(
     SEXP repo,

--- a/src/git2r_config.c
+++ b/src/git2r_config.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 #include "buffer.h"
 
 #include "git2r_arg.h"

--- a/src/git2r_config.c
+++ b/src/git2r_config.c
@@ -17,7 +17,6 @@
  */
 
 #include <git2.h>
-#include "buffer.h"
 
 #include "git2r_arg.h"
 #include "git2r_error.h"
@@ -482,7 +481,7 @@ SEXP git2r_config_find_file(SEXP level)
 {
     int not_found = 1;
     SEXP result;
-    git_buf buf = GIT_BUF_INIT;
+    git_buf buf = GIT_BUF_INIT_CONST(NULL, 0);
 
     if (git2r_arg_check_string(level))
         git2r_error(__func__, NULL, "'level'", git2r_err_string_arg);
@@ -500,7 +499,7 @@ SEXP git2r_config_find_file(SEXP level)
     if (not_found)
         SET_STRING_ELT(result, 0, NA_STRING);
     else
-        SET_STRING_ELT(result, 0, Rf_mkChar(git_buf_cstr(&buf)));
+        SET_STRING_ELT(result, 0, Rf_mkChar(buf.ptr));
 
     git_buf_free(&buf);
     UNPROTECT(1);

--- a/src/git2r_cred.c
+++ b/src/git2r_cred.c
@@ -108,8 +108,8 @@ static int git2r_cred_env(
 
         error = git_cred_userpass_plaintext_new(
             cred,
-            git_buf_cstr(&username),
-            git_buf_cstr(&password));
+            username.ptr,
+            password.ptr);
 
     cleanup:
         git_buf_free(&username);
@@ -149,7 +149,7 @@ static int git2r_cred_token(
         if (error)
             goto cleanup;
 
-        error = git_cred_userpass_plaintext_new(cred, " ", git_buf_cstr(&token));
+        error = git_cred_userpass_plaintext_new(cred, " ", token.ptr);
 
     cleanup:
         git_buf_free(&token);

--- a/src/git2r_cred.c
+++ b/src/git2r_cred.c
@@ -19,8 +19,8 @@
 #include <R.h>
 #include <Rinternals.h>
 
+#include <git2.h>
 #include "buffer.h"
-#include "common.h"
 
 #include "git2r_cred.h"
 #include "git2r_objects.h"

--- a/src/git2r_cred.h
+++ b/src/git2r_cred.h
@@ -19,7 +19,7 @@
 #ifndef INCLUDE_git2r_cred_h
 #define INCLUDE_git2r_cred_h
 
-#include "git2.h"
+#include <git2.h>
 
 int git2r_cred_acquire_cb(
     git_cred **out,

--- a/src/git2r_diff.c
+++ b/src/git2r_diff.c
@@ -23,9 +23,9 @@
 #include "git2r_tree.h"
 #include "git2r_repository.h"
 
-#include "git2.h"
+#include <git2.h>
+#include <git2/sys/diff.h>
 #include "buffer.h"
-#include "diff.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/git2r_diff.c
+++ b/src/git2r_diff.c
@@ -25,7 +25,7 @@
 
 #include <git2.h>
 #include <git2/sys/diff.h>
-#include "buffer.h"
+#include "cc-compat.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -163,13 +163,12 @@ SEXP git2r_diff_index_to_wd(SEXP repo, SEXP filename)
 
         error = git2r_diff_format_to_r(diff, result);
     } else if (0 == Rf_length(filename)) {
-        git_buf buf = GIT_BUF_INIT;
+        git_buf buf = GIT_BUF_INIT_CONST(NULL, 0);
 
-        error = git_diff_print(
+        error = git_diff_to_buf(
+            &buf,
             diff,
-            GIT_DIFF_FORMAT_PATCH,
-            git_diff_print_callback__to_buf,
-            &buf);
+            GIT_DIFF_FORMAT_PATCH);
         if (!error) {
             PROTECT(result = Rf_mkString(buf.ptr));
             nprotect++;
@@ -267,13 +266,12 @@ SEXP git2r_diff_head_to_index(SEXP repo, SEXP filename)
 
         error = git2r_diff_format_to_r(diff, result);
     } else if (0 == Rf_length(filename)) {
-        git_buf buf = GIT_BUF_INIT;
+        git_buf buf = GIT_BUF_INIT_CONST(NULL, 0);
 
-        error = git_diff_print(
+        error = git_diff_to_buf(
+            &buf,
             diff,
-            GIT_DIFF_FORMAT_PATCH,
-            git_diff_print_callback__to_buf,
-            &buf);
+            GIT_DIFF_FORMAT_PATCH);
         if (!error) {
             PROTECT(result = Rf_mkString(buf.ptr));
             nprotect++;
@@ -373,13 +371,12 @@ SEXP git2r_diff_tree_to_wd(SEXP tree, SEXP filename)
 
         error = git2r_diff_format_to_r(diff, result);
     } else if (0 == Rf_length(filename)) {
-        git_buf buf = GIT_BUF_INIT;
+        git_buf buf = GIT_BUF_INIT_CONST(NULL, 0);
 
-        error = git_diff_print(
+        error = git_diff_to_buf(
+            &buf,
             diff,
-            GIT_DIFF_FORMAT_PATCH,
-            git_diff_print_callback__to_buf,
-            &buf);
+            GIT_DIFF_FORMAT_PATCH);
         if (!error) {
             PROTECT(result = Rf_mkString(buf.ptr));
             nprotect++;
@@ -484,13 +481,12 @@ SEXP git2r_diff_tree_to_index(SEXP tree, SEXP filename)
 
         error = git2r_diff_format_to_r(diff, result);
     } else if (0 == Rf_length(filename)) {
-        git_buf buf = GIT_BUF_INIT;
+        git_buf buf = GIT_BUF_INIT_CONST(NULL, 0);
 
-        error = git_diff_print(
+        error = git_diff_to_buf(
+            &buf,
             diff,
-            GIT_DIFF_FORMAT_PATCH,
-            git_diff_print_callback__to_buf,
-            &buf);
+            GIT_DIFF_FORMAT_PATCH);
         if (!error) {
             PROTECT(result = Rf_mkString(buf.ptr));
             nprotect++;
@@ -611,13 +607,12 @@ SEXP git2r_diff_tree_to_tree(SEXP tree1, SEXP tree2, SEXP filename)
 
         error = git2r_diff_format_to_r(diff, result);
     } else if (0 == Rf_length(filename)) {
-        git_buf buf = GIT_BUF_INIT;
+        git_buf buf = GIT_BUF_INIT_CONST(NULL, 0);
 
-        error = git_diff_print(
+        error = git_diff_to_buf(
+            &buf,
             diff,
-            GIT_DIFF_FORMAT_PATCH,
-            git_diff_print_callback__to_buf,
-            &buf);
+            GIT_DIFF_FORMAT_PATCH);
         if (!error) {
             PROTECT(result = Rf_mkString(buf.ptr));
             nprotect++;

--- a/src/git2r_error.c
+++ b/src/git2r_error.c
@@ -17,7 +17,7 @@
  */
 
 #include <Rinternals.h>
-#include "git2.h"
+#include <git2.h>
 
 /**
  * Error messages

--- a/src/git2r_error.h
+++ b/src/git2r_error.h
@@ -19,7 +19,7 @@
 #ifndef INCLUDE_git2r_error_h
 #define INCLUDE_git2r_error_h
 
-#include "git2.h"
+#include <git2.h>
 
 /**
  * Error messages

--- a/src/git2r_graph.c
+++ b/src/git2r_graph.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_error.h"

--- a/src/git2r_index.c
+++ b/src/git2r_index.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_error.h"

--- a/src/git2r_libgit2.c
+++ b/src/git2r_libgit2.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 #include "git2r_arg.h"
 #include "git2r_error.h"
 #include "git2r_libgit2.h"

--- a/src/git2r_merge.c
+++ b/src/git2r_merge.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 #include "buffer.h"
 
 #include "git2r_arg.h"

--- a/src/git2r_note.c
+++ b/src/git2r_note.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 #include "buffer.h"
 
 #include "git2r_arg.h"

--- a/src/git2r_object.c
+++ b/src/git2r_object.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_blob.h"

--- a/src/git2r_odb.c
+++ b/src/git2r_odb.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 #include "buffer.h"
 
 #include "git2r_arg.h"

--- a/src/git2r_oid.h
+++ b/src/git2r_oid.h
@@ -21,7 +21,7 @@
 
 #include <R.h>
 #include <Rinternals.h>
-#include "git2.h"
+#include <git2.h>
 
 void git2r_oid_from_sha_sexp(SEXP sha, git_oid *oid);
 

--- a/src/git2r_push.c
+++ b/src/git2r_push.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_cred.h"

--- a/src/git2r_reference.c
+++ b/src/git2r_reference.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_error.h"

--- a/src/git2r_reflog.c
+++ b/src/git2r_reflog.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_error.h"

--- a/src/git2r_remote.c
+++ b/src/git2r_remote.c
@@ -16,8 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
-#include "common.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_cred.h"

--- a/src/git2r_repository.c
+++ b/src/git2r_repository.c
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "buffer.h"
+
 #include "git2r_arg.h"
 #include "git2r_blob.h"
 #include "git2r_branch.h"
@@ -26,7 +28,6 @@
 #include "git2r_signature.h"
 #include "git2r_tag.h"
 #include "git2r_tree.h"
-#include "buffer.h"
 
 /**
  * Get repo from S3 class git_repository

--- a/src/git2r_repository.c
+++ b/src/git2r_repository.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "buffer.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_blob.h"
@@ -509,7 +509,7 @@ SEXP git2r_repository_discover(SEXP path, SEXP ceiling)
 {
     int error, nprotect = 0;
     SEXP result = R_NilValue;
-    git_buf buf = GIT_BUF_INIT;
+    git_buf buf = GIT_BUF_INIT_CONST(NULL, 0);
     const char *ceiling_dirs = NULL;
 
     if (git2r_arg_check_string(path))

--- a/src/git2r_repository.h
+++ b/src/git2r_repository.h
@@ -22,7 +22,7 @@
 #include <R.h>
 #include <Rinternals.h>
 
-#include "git2.h"
+#include <git2.h>
 
 git_repository* git2r_repository_open(SEXP repo);
 SEXP git2r_repository_can_open(SEXP path);

--- a/src/git2r_reset.c
+++ b/src/git2r_reset.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_commit.h"

--- a/src/git2r_revparse.c
+++ b/src/git2r_revparse.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_blob.h"

--- a/src/git2r_revwalk.c
+++ b/src/git2r_revwalk.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 
 #include "git2r_arg.h"
 #include "git2r_commit.h"

--- a/src/git2r_signature.h
+++ b/src/git2r_signature.h
@@ -21,7 +21,7 @@
 
 #include <R.h>
 #include <Rinternals.h>
-#include "git2.h"
+#include <git2.h>
 
 SEXP git2r_signature_default(SEXP repo);
 int git2r_signature_from_arg(git_signature **out, SEXP signature);

--- a/src/git2r_stash.c
+++ b/src/git2r_stash.c
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "git2.h"
+#include <git2.h>
 #include "cc-compat.h"
 
 #include "git2r_arg.h"

--- a/src/git2r_tag.c
+++ b/src/git2r_tag.c
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "util.h"
+
 #include "git2r_arg.h"
 #include "git2r_blob.h"
 #include "git2r_commit.h"
@@ -25,8 +27,6 @@
 #include "git2r_signature.h"
 #include "git2r_tag.h"
 #include "git2r_tree.h"
-
-#include "util.h"
 
 /**
  * Init slots in S3 class git_tag

--- a/src/git2r_tag.h
+++ b/src/git2r_tag.h
@@ -22,7 +22,7 @@
 #include <R.h>
 #include <Rinternals.h>
 
-#include "git2.h"
+#include <git2.h>
 
 void git2r_tag_init(git_tag *source, SEXP repo, SEXP dest);
 SEXP git2r_tag_create(SEXP repo, SEXP name, SEXP message, SEXP tagger);

--- a/src/git2r_transfer.h
+++ b/src/git2r_transfer.h
@@ -21,7 +21,7 @@
 
 #include <R.h>
 #include <Rinternals.h>
-#include "git2.h"
+#include <git2.h>
 
 /**
  * Data structure to hold information when performing a clone, fetch

--- a/src/git2r_tree.h
+++ b/src/git2r_tree.h
@@ -22,7 +22,7 @@
 #include <R.h>
 #include <Rinternals.h>
 
-#include "git2.h"
+#include <git2.h>
 
 void git2r_tree_init(const git_tree *source, SEXP repo, SEXP dest);
 SEXP git2r_tree_walk(SEXP tree, SEXP recursive);


### PR DESCRIPTION
The git-buf API is mostly internal to libgit2. Where an equivalent public API exists, this PR changes to those functions instead. This reduces the chances of breaking changes when updating libgit2 as there is less dependency on internals.

This PR is based on #336, so it looks a bit larger than it really is. The individual commits should be relatively straightforward though.