### PR TITLE
Timestamp issue

### DIFF
--- a/R/time.R
+++ b/R/time.R
@@ -21,7 +21,7 @@ as.character.git_time <- function(x, ...) {
 
 ##' @export
 as.POSIXct.git_time <- function(x, ...) {
-    as.POSIXct(x$time + x$offset*60, origin = "1970-01-01", tz = "GMT")
+    as.POSIXct(x$time, origin = "1970-01-01", tz = "GMT")
 }
 
 ## setAs(from = "POSIXlt",

--- a/src/git2r_odb.c
+++ b/src/git2r_odb.c
@@ -467,7 +467,7 @@ static int git2r_odb_blobs_cb(const git_oid *oid, void *payload)
             "",
             sha,
             author->name,
-            (double)(author->when.time) + 60 * (double)(author->when.offset),
+            (double)(author->when.time),
             p);
 
     cleanup:

--- a/tests/time.R
+++ b/tests/time.R
@@ -22,7 +22,9 @@ sessionInfo()
 ## Test to coerce
 git_t <- structure(list(time = 1395567947, offset = 60),
                    class = "git_time")
-stopifnot(identical(as.character(git_t), "2014-03-23 10:45:47"))
+stopifnot(identical(as.character(git_t), "2014-03-23 09:45:47"))
 stopifnot(identical(as.POSIXct(git_t),
-                    as.POSIXct(1395571547, origin="1970-01-01", tz="GMT")))
+                    as.POSIXct(1395567947, origin="1970-01-01", tz="GMT")))
 stopifnot(identical(print(git_t), git_t))
+
+as.POSIXct(1395567947, origin="1970-01-01", tz = "-03")

--- a/tests/when.R
+++ b/tests/when.R
@@ -22,11 +22,11 @@ sessionInfo()
 ## Check when method
 w1 = structure(list(time = 1395567947, offset = 60),
                class = "git_time")
-stopifnot(identical(when(w1), "2014-03-23 10:45:47"))
+stopifnot(identical(when(w1), "2014-03-23 09:45:47"))
 
 s1 <- structure(list(name = "Alice", email = "alice@example.org", when = w1),
                 class = "git_signature")
-stopifnot(identical(when(s1), "2014-03-23 10:45:47"))
+stopifnot(identical(when(s1), "2014-03-23 09:45:47"))
 
 w2 = structure(list(time = 1395567950, offset = 60),
                class = "git_time")
@@ -38,7 +38,7 @@ c1 <- structure(list(sha = "166f3f779fd7e4165aaa43f2828050ce040052b0",
                      summary = "A commit summary",
                      message = "A commit message"),
                 class = "git_commit")
-stopifnot(identical(when(c1), "2014-03-23 10:45:47"))
+stopifnot(identical(when(c1), "2014-03-23 09:45:47"))
 
 t1 <- structure(list(sha = "166f3f779fd7e4165aaa43f2828050ce040052b0",
                      message = "A tag message",
@@ -46,4 +46,4 @@ t1 <- structure(list(sha = "166f3f779fd7e4165aaa43f2828050ce040052b0",
                      tagger = s1,
                      target = "166f3f779fd7e4165aaa43f2828050ce040052b0"),
                 class = "git_tag")
-stopifnot(identical(when(t1), "2014-03-23 10:45:47"))
+stopifnot(identical(when(t1), "2014-03-23 09:45:47"))


### PR DESCRIPTION
This is a better fix than #392. It requires no changes to the unit tests of the `git2rdata`. So there there is no issue synchronising both packages.