### PR TITLE
Test ls_tree() with subfolder.

### DIFF
--- a/tests/ls_tree.R
+++ b/tests/ls_tree.R
@@ -1,0 +1,64 @@
+## git2r, R bindings to the libgit2 library.
+## Copyright (C) 2013-2019 The git2r contributors
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License, version 2,
+## as published by the Free Software Foundation.
+##
+## git2r is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+library("git2r")
+
+## For debugging
+sessionInfo()
+
+## Initialize a temporary repository
+path <- tempfile(pattern="git2r-")
+dir.create(path)
+dir.create(file.path(path, "subfolder"))
+repo <- init(path)
+
+## Create a user
+config(repo, user.name="Alice", user.email="alice@example.org")
+
+## Create three files and commit
+writeLines("First file",  file.path(path, "example-1.txt"))
+writeLines("Second file", file.path(path, "subfolder/example-2.txt"))
+writeLines("Third file",  file.path(path, "example-3.txt"))
+add(repo, c("example-1.txt", "subfolder/example-2.txt", "example-3.txt"))
+commit(repo, "Commit message")
+
+## Traverse tree entries and its subtrees.
+## Various approaches that give identical result.
+stopifnot(identical(ls_tree(tree = tree(last_commit(path))),
+                    ls_tree(tree = tree(last_commit(repo)))))
+stopifnot(identical(ls_tree(repo = path), ls_tree(repo = repo)))
+
+## ls_tree(repo = repo) should match `git ls-tree -lr HEAD`
+ls_tree_result <- ls_tree(repo = repo)
+stopifnot(identical(ls_tree_result$name,
+                    c("example-1.txt", "example-3.txt", "example-2.txt")))
+
+# Argument `tree` can be a  'character that identifies a tree in the repository'
+ls_tree(tree = tree(last_commit(path))$sha, repo = repo)
+
+## Skip content in subfolder
+ls_tree_toplevel <- ls_tree(repo = repo, recursive = FALSE)
+stopifnot(nrow(ls_tree_toplevel) == 3)
+stopifnot(identical(ls_tree_toplevel$name,
+                    c("example-1.txt", "example-3.txt", "subfolder")))
+
+## Start in subfolder
+ls_tree_subfolder <- ls_tree(tree = "HEAD:subfolder", repo = repo)
+stopifnot(nrow(ls_tree_subfolder) == 1)
+stopifnot(identical(ls_tree_subfolder$name, "example-2.txt"))
+
+## Cleanup
+unlink(path, recursive = TRUE)


### PR DESCRIPTION
I was testing out the function `ls_tree()` and observed some strange behavior. I noticed that the tests in `tests/tree.R` did not cover the use cases described in `man/ls_tree.Rd`. Specifically, the presence of a subfolder gives `ls_tree()` problems.

This PR converts the examples from `?ls_tree` into a test file. It also adds additional tests corresponding to the results of `git ls-tree`.

To compare, below is the output of `git ls-tree -lr HEAD`. There are 3 lines corresponding to the 3 files in the repository.

```
$ git ls-tree -lr HEAD
100644 blob 4c5fd919d52e3c1b08f7924cfa05d6de100912fd      11    example-1.txt
100644 blob f89598da398eb016c504a5e272cb3eb1a31e2687      11    example-3.txt
100644 blob 20d5b672a347112783818b3fc8cc7cd66ade3008      12    subfolder/example-2.txt
```

In contrast, `ls_tree()` returns 4 lines. It includes the tree subfolder as its own line, and then the final line does not include the file inside the subfolder.

```
ls_tree(repo = repo)
    mode type                                      sha path          name   len
1 100644 blob 4c5fd919d52e3c1b08f7924cfa05d6de100912fd      example-1.txt    11
2 100644 blob f89598da398eb016c504a5e272cb3eb1a31e2687      example-3.txt    11
3 040000 tree 10cf266f7fd804e61b37419841a45699bc6fe74b          subfolder    NA
4                                                                         21899
```

Lastly, I found it strange that the argument `tree` accepts the characters `"HEAD:subfolder"` and `"HEAD:"`, but not `"HEAD"`.

```
> ls_tree(tree = "HEAD:", repo = repo)
    mode type                                      sha path          name   len
1 100644 blob 4c5fd919d52e3c1b08f7924cfa05d6de100912fd      example-1.txt    11
2 100644 blob f89598da398eb016c504a5e272cb3eb1a31e2687      example-3.txt    11
3 040000 tree 10cf266f7fd804e61b37419841a45699bc6fe74b          subfolder    NA
4                                                                         21899
> ls_tree(tree = "HEAD", repo = repo)
Error in data.frame(.Call(git2r_tree_walk, tree, recursive), stringsAsFactors = FALSE) : 
  Error in 'git2r_tree_walk': 'tree' must be an S3 class git_tree
```