### PR TITLE
Tests paths from a subdirectory of the Git repo

### DIFF
--- a/tests/subdirectory-absolute.R
+++ b/tests/subdirectory-absolute.R
@@ -1,0 +1,68 @@
+## git2r, R bindings to the libgit2 library.
+## Copyright (C) 2013-2019 The git2r contributors
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License, version 2,
+## as published by the Free Software Foundation.
+##
+## git2r is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+## Testing use of absolute paths when the working directory is a subdirectory
+
+library("git2r")
+
+## For debugging
+sessionInfo()
+
+## Initialize a temporary repository
+path <- tempfile(pattern = "git2r-")
+dir.create(path)
+dir.create(file.path(path, "subfolder"))
+repo <- init(path)
+
+## Create a user
+config(repo, user.name = "Alice", user.email = "alice@example.org")
+
+# Change working directory to subdirectory
+cwd <- setwd(file.path(path,  "subfolder"))
+
+## Create two files
+root <- file.path(path, "root.txt")
+sub <- file.path(path, "subfolder", "sub.txt")
+writeLines("root file",  root)
+writeLines("sub file", sub)
+
+## Add and commit
+add(repo, c(root, sub))
+commit(repo, "Add files")
+
+## Check commits
+commits_root <- commits(repo, path = root)
+stopifnot(length(commits_root) == 1)
+commits_sub <- commits(repo, path = sub)
+stopifnot(length(commits_sub) == 1)
+stopifnot(identical(commits_root, commits_sub))
+
+## Remove and commit
+rm_file(repo, c(root, sub))
+commit(repo, "Remove files")
+
+## Check commits
+commits_total <- commits(repo)
+stopifnot(length(commits_total) == 2)
+commits_root_rm <- commits(repo, path = root)
+stopifnot(length(commits_root_rm) == 2)
+commits_sub_rm <- commits(repo, path = sub)
+stopifnot(length(commits_sub_rm) == 2)
+stopifnot(identical(commits_root_rm, commits_sub_rm))
+
+## Cleanup
+setwd(cwd)
+unlink(path, recursive = TRUE)

--- a/tests/subdirectory-relative.R
+++ b/tests/subdirectory-relative.R
@@ -1,0 +1,68 @@
+## git2r, R bindings to the libgit2 library.
+## Copyright (C) 2013-2019 The git2r contributors
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License, version 2,
+## as published by the Free Software Foundation.
+##
+## git2r is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+## Testing use of relative paths when the working directory is a subdirectory
+
+library("git2r")
+
+## For debugging
+sessionInfo()
+
+## Initialize a temporary repository
+path <- tempfile(pattern = "git2r-")
+dir.create(path)
+dir.create(file.path(path, "subfolder"))
+repo <- init(path)
+
+## Create a user
+config(repo, user.name = "Alice", user.email = "alice@example.org")
+
+# Change working directory to subdirectory
+cwd <- setwd(file.path(path,  "subfolder"))
+
+## Create two files
+root <- "../root.txt"
+sub <- "sub.txt"
+writeLines("root file",  root)
+writeLines("sub file", sub)
+
+## Add and commit
+add(repo, c(root, sub))
+commit(repo, "Add files")
+
+## Check commits
+commits_root <- commits(repo, path = root)
+stopifnot(length(commits_root) == 1)
+commits_sub <- commits(repo, path = sub)
+stopifnot(length(commits_sub) == 1)
+stopifnot(identical(commits_root, commits_sub))
+
+## Remove and commit
+rm_file(repo, c(root, sub))
+commit(repo, "Remove files")
+
+## Check commits
+commits_total <- commits(repo)
+stopifnot(length(commits_total) == 2)
+commits_root_rm <- commits(repo, path = root)
+stopifnot(length(commits_root_rm) == 2)
+commits_sub_rm <- commits(repo, path = sub)
+stopifnot(length(commits_sub_rm) == 2)
+stopifnot(identical(commits_root_rm, commits_sub_rm))
+
+## Cleanup
+setwd(cwd)
+unlink(path, recursive = TRUE)


### PR DESCRIPTION
I added some tests related to the observations in Issue #394.

Currently the behavior of functions like `add()`, `rm_file()`, and `commits(path)` change based on the operating system, the current working directory, whether or not the file exists, and the type of file path (relative versus absolute).

As an example, when the file exists, the commands `commits(repo, path = "../root.txt")` and `commits(repo, path = "root.txt")` both return the commits that touch the file `root.txt` in the root of the Git repo. After the file has been removed, `commits(repo, path = "../root.txt")` returns an empty list, but `commits(repo, path = "root.txt")` still works.

```
> file.exists("../root.txt")
[1] TRUE
> commits(repo, path = "../root.txt")
[[1]]
[a7f30ea] 2019-11-07: Add files

> commits(repo, path = "root.txt")
[[1]]
[a7f30ea] 2019-11-07: Add files

> ## Remove and commit
> rm_file(repo, c(root, sub))
> commit(repo, "Remove files")
[1d77e3b] 2019-11-07: Remove files
> # after removing the file
> file.exists("../root.txt")
[1] FALSE
> commits(repo, path = "../root.txt")
list()
> commits(repo, path = "root.txt")
[[1]]
[1d77e3b] 2019-11-07: Remove files

[[2]]
[a7f30ea] 2019-11-07: Add files
```

The crux of the problem is that relative paths are interpreted in 2 distinct ways:  relative to the current working directory or relative to the root of the Git repository.