### PR TITLE
Update clone function docs and params

### DIFF
--- a/R/repository.R
+++ b/R/repository.R
@@ -208,7 +208,7 @@ init <- function(path = ".", bare = FALSE, branch = NULL) {
 
 ##' Clone a remote repository
 ##'
-##' @param url The remote repository to clone
+##' @param url The remote repository to clone, or a local repository path.
 ##' @param local_path Local directory to clone to.
 ##' @param bare Create a bare repository. Default is FALSE.
 ##' @param branch The name of the branch to checkout. Default is NULL
@@ -267,8 +267,8 @@ init <- function(path = ".", bare = FALSE, branch = NULL) {
 ##' commits(repo_1)
 ##' commits(repo_2)
 ##' }
-clone <- function(url         = NULL,
-                  local_path  = NULL,
+clone <- function(url,
+                  local_path,
                   bare        = FALSE,
                   branch      = NULL,
                   checkout    = TRUE,

--- a/man/clone.Rd
+++ b/man/clone.Rd
@@ -5,8 +5,8 @@
 \title{Clone a remote repository}
 \usage{
 clone(
-  url = NULL,
-  local_path = NULL,
+  url,
+  local_path,
   bare = FALSE,
   branch = NULL,
   checkout = TRUE,
@@ -15,7 +15,7 @@ clone(
 )
 }
 \arguments{
-\item{url}{The remote repository to clone}
+\item{url}{The remote repository to clone, or a local repository path.}
 
 \item{local_path}{Local directory to clone to.}
 


### PR DESCRIPTION
Small PR to update documentation of the `clone()` function.

1. Clarified that the `url` parameter also accepts a local repository. While this isn't explicitly documented in libgit2, it might be a good point to clarify in wrappers like `git2r`.
2. The @params  `url` and `local_path` are set by default equal to `NULL` but they are mandatory.