### PR TITLE
Switch linking on Windows to use pkg-config when available.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,8 +1,14 @@
 PKG_CPPFLAGS = -DR_NO_REMAP -DSTRICT_R_HEADERS
 
-PKG_LIBS = \
-        -lgit2 -lpcre -lssh2 -lz -lssl -lcrypto -lgcrypt -lgpg-error \
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  PKG_LIBS = \
+        -lgit2 -lpcre -lpcre -lssh2 -lz -lssl -lcrypto -lgcrypt -lgpg-error \
         -lwinhttp -lws2_32 -lcrypt32 -lole32 -lrpcrt4
+  PKG_CPPFLAGS += -DPCRE_STATIC
+else
+  PKG_LIBS = $(shell pkg-config --libs libgit2)
+  PKG_CPPFLAGS += $(shell pkg-config --cflags libgit2)
+endif
 
 all: clean
 


### PR DESCRIPTION
This patch switches to using pkg-config to establish libraries to link (and C preprocessor directives to use) on Windows. This allows the package to work with an upcoming version of Rtools, which includes libgit2 linked against pcre2 (previously, pcre 1 was used). Pkg-config is used conditionally; when it is not available, the old hard-coded linking is used assuming pcre 1. With this patch applied, the package builds with Rtools42,43,44 and upcoming 45 on my system - with the matching versions of R.
